### PR TITLE
Fix for sqlalchemy 1.3

### DIFF
--- a/flask_potion/contrib/alchemy/manager.py
+++ b/flask_potion/contrib/alchemy/manager.py
@@ -328,10 +328,18 @@ class SQLAlchemyManager(RelationalManager):
     def relation_remove(self, item, attribute, target_resource, target_item):
         before_remove_from_relation.send(self.resource, item=item, attribute=attribute, child=target_item)
         try:
-            getattr(item, attribute).remove(target_item)
-            after_remove_from_relation.send(self.resource, item=item, attribute=attribute, child=target_item)
+            collection = getattr(item, attribute)
         except ValueError:
             pass  # if the relation does not exist, do nothing
+        else:
+            if target_item in collection:
+                collection.remove(target_item)
+                after_remove_from_relation.send(
+                    self.resource,
+                    item=item,
+                    attribute=attribute,
+                    child=target_item,
+                )
 
     def commit(self):
         session = self._get_session()


### PR DESCRIPTION
Accessing a collection not yet set doesn't raise AttributeError anymore