### PR TITLE
Let __init__ of your model get access to all given properties

### DIFF
--- a/flask_potion/contrib/alchemy/manager.py
+++ b/flask_potion/contrib/alchemy/manager.py
@@ -258,10 +258,7 @@ class SQLAlchemyManager(RelationalManager):
 
     def create(self, properties, commit=True):
         # noinspection properties
-        item = self.model()
-
-        for key, value in properties.items():
-            setattr(item, key, value)
+        item = self.model(**properties)
 
         before_create.send(self.resource, item=item)
 


### PR DESCRIPTION
In some scenario your model might define some default values
 based on properties given at creation time.
This is only possible if __init__ receives all properties at once.