### PR TITLE
Don't delete an instance not yet in the session, instead expunge it.

### DIFF
--- a/flask_potion/contrib/alchemy/manager.py
+++ b/flask_potion/contrib/alchemy/manager.py
@@ -323,7 +323,10 @@ class SQLAlchemyManager(RelationalManager):
         with session.begin_nested():
             before_delete.send(self.resource, item=item)
             try:
-                session.delete(item)
+                if item in session.new:
+                    session.expunge(item)
+                else:
+                    session.delete(item)
                 session.flush()
             except IntegrityError as exc:
 


### PR DESCRIPTION
Solution given by sqlqlchemy maintainer, on this thread:

https://stackoverflow.com/questions/8306506/deleting-an-object-from-an-sqlalchemy-session-before-its-been-persisted